### PR TITLE
Standardize page headers and update UI colors

### DIFF
--- a/account-deletion.html
+++ b/account-deletion.html
@@ -526,14 +526,18 @@
         </div>
     </header>
 
-    <a href="profile.html" class="back-button">
-        <i class="fas fa-arrow-left"></i>
-    </a>
+    <div class="page-header">
+        <div class="container">
+            <a href="profile.html" class="standard-back-button">
+                <i class="fas fa-arrow-left"></i>
+            </a>
+            <h1 class="standard-page-title">Delete My Account</h1>
+        </div>
+    </div>
 
     <div class="deletion-container">
         <!-- Header Section -->
         <div class="deletion-header">
-            <h1 class="deletion-title">Delete My Account</h1>
             <p class="deletion-description">
                 Request to delete your account. Once deleted, all your saved information including orders, addresses, wishlist, and rewards will be permanently removed.
             </p>

--- a/account-settings.html
+++ b/account-settings.html
@@ -545,11 +545,13 @@
     <!-- Main Content -->
     <main class="settings-container">
         <!-- Header -->
-        <div class="settings-header">
-            <a href="profile.html" class="settings-back-btn">
-                <i class="fas fa-arrow-left"></i>
-            </a>
-            <h1 class="settings-title">Account Settings</h1>
+        <div class="page-header">
+            <div class="container">
+                <a href="profile.html" class="standard-back-button">
+                    <i class="fas fa-arrow-left"></i>
+                </a>
+                <h1 class="standard-page-title">Account Settings</h1>
+            </div>
         </div>
 
         <!-- Profile Edit Section -->

--- a/category.html
+++ b/category.html
@@ -93,14 +93,12 @@
     </header>
 
     <!-- Page Title Section -->
-    <div class="page-title-section">
+    <div class="page-header">
         <div class="container">
-            <div class="page-title-content">
-                <button class="back-button" onclick="goBack()">
-                    <i class="fas fa-arrow-left"></i>
-                </button>
-                <h1 class="page-title" id="categoryPageTitle">Categories</h1>
-            </div>
+            <button class="standard-back-button" onclick="goBack()">
+                <i class="fas fa-arrow-left"></i>
+            </button>
+            <h1 class="standard-page-title" id="categoryPageTitle">Categories</h1>
         </div>
     </div>
 

--- a/checkout.html
+++ b/checkout.html
@@ -44,12 +44,12 @@
     </header>
 
     <!-- Page Header -->
-    <div class="checkout-page-header">
+    <div class="page-header">
         <div class="container">
-            <button class="back-button" onclick="goBack()">
+            <button class="standard-back-button" onclick="goBack()">
                 <i class="fas fa-arrow-left"></i>
             </button>
-            <h1 class="page-title">Checkout</h1>
+            <h1 class="standard-page-title">Checkout</h1>
         </div>
     </div>
 

--- a/delivery-management.html
+++ b/delivery-management.html
@@ -841,10 +841,7 @@
         </div>
     </div>
 
-    <!-- Floating Add Button -->
-    <button class="floating-add-btn" onclick="openAddAddressModal()" title="Add New Address">
-        <i class="fas fa-plus"></i>
-    </button>
+    <!-- Floating Add Button - Removed as requested -->
 
     <!-- Add/Edit Address Modal -->
     <div id="addressModal" class="modal">

--- a/delivery-management.html
+++ b/delivery-management.html
@@ -647,12 +647,12 @@
     </header>
 
     <!-- Page Header -->
-    <div class="delivery-page-header">
+    <div class="page-header">
         <div class="container">
-            <button class="back-button" onclick="goBack()">
+            <button class="standard-back-button" onclick="goBack()">
                 <i class="fas fa-arrow-left"></i>
             </button>
-            <h1 class="page-title">Delivery Management</h1>
+            <h1 class="standard-page-title">Delivery Management</h1>
         </div>
     </div>
 

--- a/delivery-management.html
+++ b/delivery-management.html
@@ -102,7 +102,7 @@
             padding: 1rem;
             transition: all 0.3s ease;
             position: relative;
-            background: #f8f9fa;
+            background: white;
         }
 
         .address-card:hover {
@@ -113,7 +113,7 @@
 
         .address-card.default {
             border-color: #28a745;
-            background: #f8fff9;
+            background: white;
         }
 
         .address-header {
@@ -143,19 +143,19 @@
         }
 
         .home-icon {
-            background: #e8f5e8;
-            color: #28a745;
+            background: white;
+            color: white;
         }
 
         .work-icon {
-            background: #f0e6ff;
-            color: #6f42c1;
+            background: white;
+            color: white;
         }
 
         .address-label {
             font-size: 0.9rem;
             font-weight: 600;
-            color: #6c757d;
+            color: white;
             letter-spacing: 0.5px;
         }
 
@@ -211,10 +211,18 @@
             justify-content: center;
         }
 
+        .action-btn.edit {
+            color: #ff8c00;
+        }
+
         .action-btn.edit:hover {
-            border-color: #007bff;
-            color: #007bff;
-            background: #f8f9ff;
+            border-color: #ff8c00;
+            color: #ff8c00;
+            background: #fff8f0;
+        }
+
+        .action-btn.delete {
+            color: #dc3545;
         }
 
         .action-btn.delete:hover {
@@ -226,13 +234,15 @@
         /* Add New Address Button */
         .add-address-container {
             position: relative;
+            display: flex;
+            justify-content: center;
+            width: 100%;
         }
 
         .add-address-btn {
-            width: 100%;
-            padding: 1rem;
+            padding: 1rem 2rem;
             border: 2px dashed #e9ecef;
-            background: #f8f9fa;
+            background: white;
             border-radius: 8px;
             cursor: pointer;
             transition: all 0.3s ease;
@@ -285,7 +295,7 @@
             padding: 1rem;
             border: 1px solid #e9ecef;
             border-radius: 8px;
-            background: #f8f9fa;
+            background: white;
         }
 
         .preference-label {

--- a/delivery-management.html
+++ b/delivery-management.html
@@ -143,12 +143,12 @@
         }
 
         .home-icon {
-            background: white;
+            background: #28a745;
             color: white;
         }
 
         .work-icon {
-            background: white;
+            background: #6f42c1;
             color: white;
         }
 

--- a/delivery-management.html
+++ b/delivery-management.html
@@ -76,7 +76,7 @@
         .section-title {
             font-size: 1.2rem;
             font-weight: 600;
-            color: #212529;
+            color: #000000;
             margin: 0 0 1.5rem 0;
             display: flex;
             align-items: center;

--- a/delivery-management.html
+++ b/delivery-management.html
@@ -86,7 +86,7 @@
         .section-icon {
             width: 24px;
             height: 24px;
-            color: #e91e63;
+            color: #000000;
         }
 
         /* Address Cards */

--- a/edit-profile.html
+++ b/edit-profile.html
@@ -239,11 +239,13 @@
 <body>
     <div class="edit-profile-container">
         <!-- Header -->
-        <div class="edit-header">
-            <a href="account-settings.html" class="edit-back-btn">
-                <i class="fas fa-arrow-left"></i>
-            </a>
-            <h1 class="edit-title">Edit Profile</h1>
+        <div class="page-header">
+            <div class="container">
+                <a href="account-settings.html" class="standard-back-button">
+                    <i class="fas fa-arrow-left"></i>
+                </a>
+                <h1 class="standard-page-title">Edit Profile</h1>
+            </div>
         </div>
 
         <!-- Form -->

--- a/help-support.html
+++ b/help-support.html
@@ -298,12 +298,12 @@
     </header>
 
     <!-- Back Button and Page Title -->
-    <div class="support-page-header">
+    <div class="page-header">
         <div class="container">
-            <button class="back-button" onclick="goBack()">
+            <button class="standard-back-button" onclick="goBack()">
                 <i class="fas fa-arrow-left"></i>
             </button>
-            <h1 class="page-title">Help & Support</h1>
+            <h1 class="standard-page-title">Help & Support</h1>
         </div>
     </div>
 

--- a/personal-info.html
+++ b/personal-info.html
@@ -214,11 +214,13 @@
 <body>
     <div class="personal-info-container">
         <!-- Header -->
-        <div class="info-header">
-            <a href="account-settings.html" class="info-back-btn">
-                <i class="fas fa-arrow-left"></i>
-            </a>
-            <h1 class="info-title">Personal Information</h1>
+        <div class="page-header">
+            <div class="container">
+                <a href="account-settings.html" class="standard-back-button">
+                    <i class="fas fa-arrow-left"></i>
+                </a>
+                <h1 class="standard-page-title">Personal Information</h1>
+            </div>
         </div>
 
         <!-- Form -->

--- a/product-detail.html
+++ b/product-detail.html
@@ -100,12 +100,12 @@
             <!-- Product Gallery Section -->
             <section class="product-gallery-section">
                 <!-- Product Navigation Header -->
-                <div class="product-nav-header">
-                    <button class="product-back-btn" id="productBackBtn">
-                        <i class="fas fa-arrow-left"></i>
-                    </button>
-                    <div class="product-nav-info">
-                        Product Details
+                <div class="page-header">
+                    <div class="container">
+                        <button class="standard-back-button" id="productBackBtn">
+                            <i class="fas fa-arrow-left"></i>
+                        </button>
+                        <h1 class="standard-page-title">Product Details</h1>
                     </div>
                 </div>
 

--- a/profile.html
+++ b/profile.html
@@ -85,13 +85,15 @@
     <main class="profile-main">
         <div class="container">
             <!-- Profile Header -->
-            <div class="profile-header-nav">
-                <button class="back-button" onclick="goBack()">
-                    <i class="fas fa-arrow-left"></i>
-                </button>
-                <div class="profile-title-section">
-                    <h1 class="main-title">My Profile</h1>
-                    <p class="subtitle">Manage your account settings and preferences</p>
+            <div class="page-header">
+                <div class="container">
+                    <button class="standard-back-button" onclick="goBack()">
+                        <i class="fas fa-arrow-left"></i>
+                    </button>
+                    <div class="profile-title-section">
+                        <h1 class="standard-page-title">My Profile</h1>
+                        <p class="subtitle">Manage your account settings and preferences</p>
+                    </div>
                 </div>
             </div>
 

--- a/saved-addresses.html
+++ b/saved-addresses.html
@@ -829,14 +829,12 @@
     </header>
 
     <!-- Page Header -->
-    <div class="addresses-header">
-        <div class="header-container">
-            <div class="header-left">
-                <button class="back-button" onclick="goBack()">
-                    <i class="fas fa-arrow-left"></i>
-                </button>
-                <h1 class="page-title">Saved Addresses</h1>
-            </div>
+    <div class="page-header">
+        <div class="container">
+            <button class="standard-back-button" onclick="goBack()">
+                <i class="fas fa-arrow-left"></i>
+            </button>
+            <h1 class="standard-page-title">Saved Addresses</h1>
             <button class="add-address-btn" onclick="showAddModal()">
                 <i class="fas fa-plus"></i>
                 Add Address

--- a/styles.css
+++ b/styles.css
@@ -1505,6 +1505,20 @@ h3::after {
     background: white !important;
 }
 
+/* Global black section icons and titles */
+.section-icon {
+    color: #000000 !important;
+}
+
+.section-title {
+    color: #000000 !important;
+}
+
+/* Hide floating add buttons */
+.floating-add-btn {
+    display: none !important;
+}
+
 /* Home and Work label colors */
 .address-label {
     color: white !important;

--- a/styles.css
+++ b/styles.css
@@ -1470,8 +1470,8 @@ body {
 
 /* Standardized Page Header with Back Button and Page Name */
 .page-header {
-    background: white;
-    border-bottom: 1px solid #e9ecef;
+    background: transparent;
+    border-bottom: none;
     padding: 1rem 0;
     margin-bottom: 2rem;
 }

--- a/styles.css
+++ b/styles.css
@@ -1476,6 +1476,43 @@ body {
     margin-bottom: 2rem;
 }
 
+/* Remove all colored decorative lines */
+.section::after,
+.section-title::after,
+h1::after,
+h2::after,
+h3::after {
+    display: none !important;
+}
+
+/* Global edit and delete icon colors */
+.action-btn.edit,
+.edit-btn,
+.fas.fa-edit {
+    color: #ff8c00 !important;
+}
+
+.action-btn.delete,
+.delete-btn,
+.fas.fa-trash {
+    color: #dc3545 !important;
+}
+
+/* Global white background for cards */
+.address-card,
+.card,
+.preference-item {
+    background: white !important;
+}
+
+/* Home and Work label colors */
+.address-label,
+.home-icon,
+.work-icon {
+    color: white !important;
+    background: white !important;
+}
+
 .page-header .container {
     display: flex;
     align-items: center;

--- a/styles.css
+++ b/styles.css
@@ -1506,11 +1506,18 @@ h3::after {
 }
 
 /* Home and Work label colors */
-.address-label,
-.home-icon,
-.work-icon {
+.address-label {
     color: white !important;
-    background: white !important;
+}
+
+.home-icon {
+    background: #28a745 !important;
+    color: white !important;
+}
+
+.work-icon {
+    background: #6f42c1 !important;
+    color: white !important;
 }
 
 .page-header .container {

--- a/styles.css
+++ b/styles.css
@@ -1506,11 +1506,19 @@ h3::after {
 }
 
 /* Global black section icons and titles */
-.section-icon {
+.section-icon,
+i.section-icon,
+.fas.fa-map-marker-alt,
+.fas.fa-cog,
+.fas.fa-truck,
+.fas.fa-history {
     color: #000000 !important;
 }
 
-.section-title {
+.section-title,
+h2.section-title,
+h1.section-title,
+h3.section-title {
     color: #000000 !important;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1468,6 +1468,52 @@ body {
     font-weight: 600;
 }
 
+/* Standardized Page Header with Back Button and Page Name */
+.page-header {
+    background: white;
+    border-bottom: 1px solid #e9ecef;
+    padding: 1rem 0;
+    margin-bottom: 2rem;
+}
+
+.page-header .container {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 20px;
+}
+
+.standard-back-button {
+    background: #f7fafc;
+    border: 1px solid #e2e8f0;
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    color: #4a5568;
+    font-size: 1.1rem;
+    text-decoration: none;
+}
+
+.standard-back-button:hover {
+    background: #edf2f7;
+    border-color: #cbd5e0;
+    transform: translateX(-2px);
+}
+
+.standard-page-title {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #000000;
+    margin: 0;
+}
+
 /* Profile Section Styles */
 .profile-section {
     position: relative;

--- a/track-order.html
+++ b/track-order.html
@@ -689,12 +689,12 @@
     </header>
 
     <!-- Page Header -->
-    <div class="track-page-header">
+    <div class="page-header">
         <div class="container">
-            <button class="back-button" onclick="goBack()">
+            <button class="standard-back-button" onclick="goBack()">
                 <i class="fas fa-arrow-left"></i>
             </button>
-            <h1 class="page-title">Track Your Order</h1>
+            <h1 class="standard-page-title">Track Your Order</h1>
         </div>
     </div>
 


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses several UI consistency and color scheme issues:
- Standardize page headers across all pages with consistent back button and title styling
- Update icon colors to improve visual hierarchy (edit icons to orange, delete icons to red)
- Change address label backgrounds for home/work to use white text on colored backgrounds
- Remove decorative colored lines throughout the application
- Hide floating add buttons and center "add new address" functionality
- Ensure section icons and titles display in black for better readability

## Code changes

- **Standardized page headers**: Replaced custom header implementations across 12+ HTML files with a unified `.page-header` structure containing `.standard-back-button` and `.standard-page-title`
- **Updated CSS color scheme**: 
  - Edit icons now use orange (#ff8c00)
  - Delete icons now use red (#dc3545) 
  - Section icons and titles now use black (#000000)
  - Address cards use white backgrounds
  - Home/work labels use white text on green/purple backgrounds respectively
- **Removed visual elements**: Hidden decorative lines and floating add buttons as requested
- **Improved layout**: Centered "add new address" button in delivery management
- **Enhanced consistency**: Applied standardized styling across account settings, profile, checkout, category, and other key pages

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 16`

🔗 [Edit in Builder.io](https://builder.io/app/projects/ec8a40d9034f46f8bd692a42d0aa7752/zenith-works)

👀 [Preview Link](https://ec8a40d9034f46f8bd692a42d0aa7752-zenith-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ec8a40d9034f46f8bd692a42d0aa7752</projectId>-->
<!--<branchName>zenith-works</branchName>-->