### PR TITLE
Fix back navigation and add wishlist item counter

### DIFF
--- a/script.js
+++ b/script.js
@@ -336,6 +336,14 @@ function updateCartCount() {
     }
 }
 
+function updateWishlistCount() {
+    const heartIcon = document.querySelector('.wishlist-icon');
+    const count = Array.isArray(wishlist) ? wishlist.length : 0;
+    if (heartIcon) {
+        heartIcon.setAttribute('data-count', String(count));
+    }
+}
+
 // Wishlist Functionality
 function handleWishlist(event) {
     event.preventDefault();
@@ -3542,7 +3550,7 @@ const subcategoryItems = {
             originalPrice: '$319',
             image: 'https://images.unsplash.com/photo-1551028719-00167b16eac5?w=400&h=400&fit=crop&auto=format&q=90',
             category: 'OUTERWEAR',
-            rating: '★★★��★'
+            rating: '★★★�����'
         },
         {
             id: 'outer2',

--- a/script.js
+++ b/script.js
@@ -87,6 +87,7 @@ function initializeApp() {
     if (typeof window.setupVideoShowcase === 'function') {
         window.setupVideoShowcase();
     }
+    updateWishlistCount();
 
     // Set default header title and hide header on homepage
     setPageHeaderTitle('Home');
@@ -3345,7 +3346,7 @@ const subcategoryItems = {
             originalPrice: '$399',
             image: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=400&h=400&fit=crop&auto=format&q=90',
             category: 'MEN FASHION',
-            rating: '★★★★★'
+            rating: '★���★★★'
         },
         {
             id: 'suit2',

--- a/script.js
+++ b/script.js
@@ -4637,7 +4637,7 @@ function setupWinterFeatures() {
     recBtns.forEach(btn => {
         btn.addEventListener('click', () => {
             const card = btn.closest('.recommendation-card');
-            const title = card.querySelector('.recommendation-title').textContent;
+            const title = card?.querySelector('.recommendation-title')?.textContent || '';
             if (card && card.classList.contains('spring-preview')) {
                 window.location.href = 'spring-collection.html';
                 return;
@@ -4646,7 +4646,11 @@ function setupWinterFeatures() {
                 window.location.href = 'winter-sale.html';
                 return;
             }
-            showNotification(`Exploring: ${title}`, 'info');
+            if (card && card.classList.contains('accessories-focus')) {
+                window.location.href = 'spring-collection.html';
+                return;
+            }
+            window.location.href = 'spring-collection.html';
         });
     });
 

--- a/script.js
+++ b/script.js
@@ -386,11 +386,13 @@ function handleWishlist(event) {
 function addToWishlist(product) {
     wishlist.push(product);
     saveWishlistToStorage();
+    updateWishlistCount();
 }
 
 function removeFromWishlist(productTitle) {
     wishlist = wishlist.filter(item => item.title !== productTitle);
     saveWishlistToStorage();
+    updateWishlistCount();
 }
 
 // Quick View functionality removed
@@ -617,7 +619,10 @@ function loadWishlistFromStorage() {
     if (savedWishlist) {
         wishlist = JSON.parse(savedWishlist);
         updateWishlistUI();
+    } else {
+        wishlist = [];
     }
+    updateWishlistCount();
 }
 
 function updateWishlistUI() {
@@ -3550,7 +3555,7 @@ const subcategoryItems = {
             originalPrice: '$319',
             image: 'https://images.unsplash.com/photo-1551028719-00167b16eac5?w=400&h=400&fit=crop&auto=format&q=90',
             category: 'OUTERWEAR',
-            rating: '★★★�����'
+            rating: '★★★��★'
         },
         {
             id: 'outer2',

--- a/script.js
+++ b/script.js
@@ -84,7 +84,9 @@ function initializeApp() {
     setupCollectionPage();
     setupCollectionNavigation();
     setupCartModal();
-    setupVideoShowcase();
+    if (typeof window.setupVideoShowcase === 'function') {
+        window.setupVideoShowcase();
+    }
 
     // Set default header title and hide header on homepage
     setPageHeaderTitle('Home');

--- a/spring-collection.html
+++ b/spring-collection.html
@@ -54,7 +54,7 @@
     <!-- Page Header -->
     <div class="page-header">
         <div class="container">
-            <button class="standard-back-button" onclick="history.back()">
+            <button class="standard-back-button" onclick="window.location.href='spring-collection.html'">
                 <i class="fas fa-arrow-left"></i>
             </button>
             <h1 class="standard-page-title">Spring Collection 2025</h1>

--- a/spring-collection.html
+++ b/spring-collection.html
@@ -54,7 +54,7 @@
     <!-- Page Header -->
     <div class="page-header">
         <div class="container">
-            <button class="standard-back-button" onclick="window.location.href='spring-collection.html'">
+            <button class="standard-back-button" onclick="window.location.href='index.html'">
                 <i class="fas fa-arrow-left"></i>
             </button>
             <h1 class="standard-page-title">Spring Collection 2025</h1>

--- a/spring-collection.js
+++ b/spring-collection.js
@@ -111,8 +111,8 @@ document.addEventListener('DOMContentLoaded', () => {
     cards.forEach(card => {
       const cardCategory = card.dataset.category;
       const cardPrice = parseInt(card.dataset.price, 10);
-      const sizes = card.dataset.sizes.split(',');
-      const colors = card.dataset.colors.split(',');
+      const sizes = (card.dataset.sizes || '').split(',').filter(Boolean);
+      const colors = (card.dataset.colors || '').split(',').filter(Boolean);
 
       let show = true;
       if (category !== 'all' && cardCategory !== category) show = false;

--- a/styles.css
+++ b/styles.css
@@ -1554,6 +1554,27 @@ body {
     font-size: 0.7rem;
     font-weight: 600;
 }
+/* Pseudo-element badge so we don't need extra markup */
+.wishlist-icon::after {
+    content: attr(data-count);
+    position: absolute;
+    top: -8px;
+    right: -10px;
+    background: #000;
+    color: #fff;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.7rem;
+    font-weight: 600;
+}
+.wishlist-icon[data-count="0"]::after,
+.wishlist-icon:not([data-count])::after {
+    display: none;
+}
 
 /* Standardized Page Header with Back Button and Page Name */
 .page-header {

--- a/styles.css
+++ b/styles.css
@@ -1538,6 +1538,23 @@ body {
     font-weight: 600;
 }
 
+.wishlist-icon { position: relative; }
+.wishlist-count {
+    position: absolute;
+    top: -8px;
+    right: -10px;
+    background: #000;
+    color: white;
+    border-radius: 50%;
+    width: 18px;
+    height: 18px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.7rem;
+    font-weight: 600;
+}
+
 /* Standardized Page Header with Back Button and Page Name */
 .page-header {
     background: transparent;

--- a/winter-sale.html
+++ b/winter-sale.html
@@ -52,7 +52,7 @@
 
   <div class="page-header">
     <div class="container">
-      <button class="standard-back-button" onclick="history.back()">
+      <button class="standard-back-button" onclick="window.location.href='spring-collection.html'">
         <i class="fas fa-arrow-left"></i>
       </button>
       <h1 class="standard-page-title">Winter Clearance Sale – Limited Time</h1>


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses two key issues:
1. **Back button navigation**: Users reported that the back icon wasn't working properly and needed to navigate to the correct collection pages (Spring Collection, Summer Collection, Autumn Collections, Winter Collections 2025)
2. **Wishlist counter**: Users requested a visual indicator showing how many items are in their wishlist

## Code Changes

### Navigation Fixes
- Updated back button in `spring-collection.html` to navigate to `index.html` instead of using `history.back()`
- Updated back button in `winter-sale.html` to navigate to `spring-collection.html`
- Enhanced recommendation button navigation logic in `setupWinterFeatures()` to properly route to spring collection page

### Wishlist Counter Implementation
- Added `updateWishlistCount()` function to display wishlist item count
- Integrated wishlist counter updates in `addToWishlist()` and `removeFromWishlist()` functions
- Added CSS styling for wishlist counter badge using pseudo-elements
- Initialized wishlist counter on app startup and when loading from storage

### Additional Improvements
- Added null safety checks for video showcase initialization
- Enhanced error handling in spring collection filtering logic
- Fixed potential null reference issues in recommendation card handling

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 38`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2497e5de867c4f2daf3c9334f2b195f9/swoosh-realm)

👀 [Preview Link](https://2497e5de867c4f2daf3c9334f2b195f9-swoosh-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2497e5de867c4f2daf3c9334f2b195f9</projectId>-->
<!--<branchName>swoosh-realm</branchName>-->